### PR TITLE
feat(dpu_x): Fix DPU X charging speed and operating mode sensor

### DIFF
--- a/custom_components/ef_ble/eflib/devices/dpu_x.py
+++ b/custom_components/ef_ble/eflib/devices/dpu_x.py
@@ -167,7 +167,7 @@ class Device(DeviceBase, ProtobufProps):
         cfg.operate_intelligent_schedule_mode_open = mode == OperatingMode.INTELLIGENT
         await self._send_config_packet(message)
 
-    @controls.power(ac_charging_speed, min=600, max=7200, step=100)
+    @controls.power(ac_charging_speed, min=600, max=12000, step=100)
     async def set_ac_charging_speed(self, watts: float):
         await self._send_config_packet(
             pd100_pb2.ConfigWrite(cfg_plug_in_info_acp_chg_pow_max=int(watts))

--- a/custom_components/ef_ble/eflib/devices/dpu_x.py
+++ b/custom_components/ef_ble/eflib/devices/dpu_x.py
@@ -142,7 +142,7 @@ class Device(DeviceBase, ProtobufProps):
         return bool(self.error_code)
 
     @computed_field
-    def energy_strategy_operate_mode(self) -> OperatingMode:
+    def dpux_operating_mode(self) -> OperatingMode:
         mode = self._energy_strategy_operate_mode
         if mode is None:
             return OperatingMode.NONE
@@ -158,7 +158,7 @@ class Device(DeviceBase, ProtobufProps):
     async def enable_ac_ports(self, enabled: bool):
         await self._send_config_packet(pd100_pb2.ConfigWrite(cfg_ac_out_open=enabled))
 
-    @controls.select(energy_strategy_operate_mode, options=OperatingMode)
+    @controls.select(dpux_operating_mode, options=OperatingMode)
     async def set_operating_mode(self, mode: OperatingMode):
         message = pd100_pb2.ConfigWrite()
         cfg = message.cfg_energy_strategy_operate_mode

--- a/custom_components/ef_ble/eflib/devices/dpu_x.py
+++ b/custom_components/ef_ble/eflib/devices/dpu_x.py
@@ -142,7 +142,7 @@ class Device(DeviceBase, ProtobufProps):
         return bool(self.error_code)
 
     @computed_field
-    def operating_mode(self) -> OperatingMode:
+    def energy_strategy_operate_mode(self) -> OperatingMode:
         mode = self._energy_strategy_operate_mode
         if mode is None:
             return OperatingMode.NONE
@@ -158,7 +158,7 @@ class Device(DeviceBase, ProtobufProps):
     async def enable_ac_ports(self, enabled: bool):
         await self._send_config_packet(pd100_pb2.ConfigWrite(cfg_ac_out_open=enabled))
 
-    @controls.select(operating_mode, options=OperatingMode)
+    @controls.select(energy_strategy_operate_mode, options=OperatingMode)
     async def set_operating_mode(self, mode: OperatingMode):
         message = pd100_pb2.ConfigWrite()
         cfg = message.cfg_energy_strategy_operate_mode


### PR DESCRIPTION
The DPUX inverter has a 12kW limit, not a 7.2kW limit like the DPU.

Also, the operating mode sensor is colliding with the Wave3 enum (like it was for sleep_state in https://github.com/GnoX/ha-ef-ble/commit/9e73e6078b382ac5293fbf227223219f7422a075)